### PR TITLE
bugfix/CON2124/csp: REFACTOR gatsby-config to resolve csp issues

### DIFF
--- a/pwa/gatsby-config.js
+++ b/pwa/gatsby-config.js
@@ -12,13 +12,15 @@ module.exports = {
         mergeScriptHashes: true,
         mergeStyleHashes: true,
         directives: {
+          "connect-src": "*",
           "script-src":
-            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/",
+            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/ 'unsafe-inline' 'unsafe-eval'",
           "style-src":
-            "'self' 'nonce-true' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/",
-          "img-src": "'self' https://demodam.nl/ data:",
+            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/ 'unsafe-inline' 'unsafe-eval'",
+          "img-src":
+            "'self' https://demodam.nl/ data: 'unsafe-inline' 'unsafe-eval'",
           "font-src":
-            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/",
+            "'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ 'unsafe-inline' 'unsafe-eval'",
         },
       },
     },


### PR DESCRIPTION
Momenteel laadt de [voorbeeld site](https://conductionnl.github.io/nl-design-skeleton-gatsby/) geen  `css` in en geeft die de volgende CPS error: 

```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' 'nonce-true' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/ https://unpkg.com/@conductionnl/ https://unpkg.com/@utrecht/ https://unpkg.com/@nl-design-system-unstable/ 'sha256-3OtxMyn3Ojf2KihuMh4LaWBvPV903uONWYjWq4IDjvU='". Either the 'unsafe-inline' keyword, a hash ('sha256-MtxTLcyxVEJFNLEIqbVTaqR4WWr0+lYSZ78AzGmNsuA='), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.
```

Ik heb de aanpassingen getest op development (met `disableOnDev: false`) en het lijkt goed te werken. 

De wildcard op `connect-src` (`"*"`) heeft te maken met een localhost connection die anders herhaaldelijk refused wordt (oplossingen zoals e.g. `'self' 'localhost'` haalde deze error niet weg).

@rjzondervan 
Wil jij even meekijken of dit security technisch oké is zo?

@smisidjan 
Wil jij kijken of dit daadwerkelijk werkt wanneer we 'm pushen naar de [voorbeeld site](https://conductionnl.github.io/nl-design-skeleton-gatsby/)? Misschien dat je mij ook even in de loop kan meenemen hoe jullie dit normaliter checken.

Thanks!